### PR TITLE
Fix unintentional writes to records rather than process

### DIFF
--- a/instronArbyApp/Db/controls.db
+++ b/instronArbyApp/Db/controls.db
@@ -150,7 +150,7 @@ record(bo, "$(P)INIT")
 record(seq, "$(P)INITSEQ")
 {
     field(DESC, "Initialize comms")   
-    field(LNK1, "$(P)READ_VAR PP")
+    field(LNK1, "$(P)READ_VAR.PROC PP")
     
     field(DO2, "3")
     field(LNK2, "$(P)AXES:RAMP:WFTYP:SP PP")
@@ -379,12 +379,12 @@ record(seq, "$(P)READ_SLOW")
     field(DO1, "0")
     field(LNK1, "$(P)WATCHDOG:STAT:SP PP")
     
-    field(LNK2, "$(P)MOVE PP")
-    field(LNK3, "$(P)STAT:FRAME PP")
-    field(LNK4, "$(P)CHANNEL:RAW PP")
+    field(LNK2, "$(P)MOVE.PROC PP")
+    field(LNK3, "$(P)STAT:FRAME.PROC PP")
+    field(LNK4, "$(P)CHANNEL:RAW.PROC PP")
 
-    field(LNK5, "$(P)CONTROLS:SPECIFIC:READALL PP")
-	field(LNK6, "$(P)WAVE:READALL PP")
+    field(LNK5, "$(P)CONTROLS:SPECIFIC:READALL.PROC PP")
+	field(LNK6, "$(P)WAVE:READALL.PROC PP")
     
     field(SCAN, "1 second")
     field(SELM, "All")
@@ -398,11 +398,11 @@ record(seq, "$(P)READ_VAR")
     field(DO1, "0")
     field(LNK1, "$(P)WATCHDOG:STAT:SP PP")
 	
-    field(LNK2, "$(P)POS:READALL PP")
-    field(LNK3, "$(P)STRESS:READALL PP")
-    field(LNK4, "$(P)STRAIN:READALL PP")
+    field(LNK2, "$(P)POS:READALL.PROC PP")
+    field(LNK3, "$(P)STRESS:READALL.PROC PP")
+    field(LNK4, "$(P)STRAIN:READALL.PROC PP")
 	
-    field(LNK5, "$(P)READ_VAR:COUNT:_CALC PP")
+    field(LNK5, "$(P)READ_VAR:COUNT:_CALC.PROC PP")
     
     field(SCAN, "1 second")
     field(SELM, "All")

--- a/instronArbyApp/Db/controls_channel.template
+++ b/instronArbyApp/Db/controls_channel.template
@@ -9,7 +9,7 @@
 # ST_PREFIX - prefix of mbbi record in channel pv for this channel
 
 
-record(seq, "$(P)$(CHAN):READALL")
+record(fanout, "$(P)$(CHAN):READALL")
 {
     field(DESC, "Read data from $(CHAN) channel")
     

--- a/instronArbyApp/Db/controls_channel_specific.db
+++ b/instronArbyApp/Db/controls_channel_specific.db
@@ -2,7 +2,7 @@
 ### General records
 ###
 
-record(seq, "$(P)CONTROLS:SPECIFIC:READALL")
+record(fanout, "$(P)CONTROLS:SPECIFIC:READALL")
 {
     # Watchdog must already be disabled
     # Called from main read all

--- a/instronArbyApp/Db/controls_waveform.db
+++ b/instronArbyApp/Db/controls_waveform.db
@@ -1,4 +1,4 @@
-record(seq, "$(P)WAVE:READALL") 
+record(fanout, "$(P)WAVE:READALL")
 {
     field(DESC, "Read all waveform data")
     field(LNK1, "$(P)WAVE:FREQ:RAW PP")


### PR DESCRIPTION
Add some `.PROC` fields and replace some `seq` records with `fanout` - I believe just processing was the intention, but in some cases this was caused indirectly by writing a value to the input record which could lead to elsewhere in the program getting an incorrect value if it chose to process at precisely the wrong time
  
See ISISComputingGroup/IBEX#7953