### PR TITLE
Add DRVH to limit max cycles

### DIFF
--- a/instronArbyApp/Db/controls_waveform.db
+++ b/instronArbyApp/Db/controls_waveform.db
@@ -527,6 +527,7 @@ record(ao, "$(P)QUART:CYCLE:SP")
     field(EGU, "")
     field(FLNK, "$(P)QUART:SP:_CALC")
     field(VAL, "0")
+    field(DRVH, "536870912") # 2^29
     field(PINI, "YES")
 }
 

--- a/instronArbyApp/Db/controls_waveform.db
+++ b/instronArbyApp/Db/controls_waveform.db
@@ -527,7 +527,7 @@ record(ao, "$(P)QUART:CYCLE:SP")
     field(EGU, "")
     field(FLNK, "$(P)QUART:SP:_CALC")
     field(VAL, "0")
-    field(DRVH, "536870912") # 2^29
+    field(DRVH, "536870911") # 2^29 - 1
     field(PINI, "YES")
 }
 


### PR DESCRIPTION
Limit max cycles to avoid number being rejected by hardware. Max signed int is `2^31 - 1` so divide by 4 for as you input cycles and it gets multiplied to quarter cycles which give `2^29 - 1` 